### PR TITLE
feat: add reset button

### DIFF
--- a/apps/dashboard/src/components/Element.tsx
+++ b/apps/dashboard/src/components/Element.tsx
@@ -237,10 +237,11 @@ export function Element({ element }: ElementProps) {
 
   return (
     <Tag
+      id={`element-${element.id}`}
+      style={style}
       className={`element cursor-default select-none !outline-blue-500 outline-1 outline-offset-[3px] hover:outline ${isSelected ? 'outline cursor-move' : ''} ${isEditing ? '!outline !cursor-text' : ''} ${element.tag === 'span' ? '!outline-dashed' : ''}`}
       // @ts-expect-error wtf?
       ref={elementRef}
-      style={style}
     >
       {element.tag === 'p' ? element.content : null}
       {element.tag === 'span' ? '[dynamic text]' : null}

--- a/apps/dashboard/src/components/LeftPanel/ModificationsSection.tsx
+++ b/apps/dashboard/src/components/LeftPanel/ModificationsSection.tsx
@@ -1,10 +1,11 @@
 import { Button } from "../Button";
 import { useOg } from "../OgEditor";
+import { DeleteIcon } from "../icons/DeleteIcon";
 import { RedoIcon } from "../icons/RedoIcon";
 import { UndoIcon } from "../icons/UndoIcon";
 
 export function ModificationSection() {
-  const { undoRedo } = useOg()
+  const { undoRedo, reset } = useOg()
 
   return (
     <>
@@ -12,6 +13,7 @@ export function ModificationSection() {
       <div className="grid grid-cols-2 gap-2 w-full">
         <Button icon={<UndoIcon />} onClick={() => { undoRedo('undo'); }}>Undo</Button>
         <Button icon={<RedoIcon />} onClick={() => { undoRedo('redo'); }}>Redo</Button>
+        <Button className="col-span-full" icon={<DeleteIcon />} onClick={() => { reset(); }} variant="danger">Reset</Button>
       </div>
     </>
   )

--- a/apps/dashboard/src/components/OgEditor.tsx
+++ b/apps/dashboard/src/components/OgEditor.tsx
@@ -17,6 +17,7 @@ interface OgContextType {
   addElement: (element: OGElement) => void
   removeElement: (id: string) => void
   undoRedo: (type: 'undo' | 'redo') => void
+  reset: () => void
   rootRef: RefObject<HTMLDivElement>
 }
 
@@ -232,6 +233,10 @@ export function OgEditor({ initialElements, width, height }: OgProviderProps) {
     }
   }, [rootRef, selectedElement, removeElement, addElement, elements, undoRedo, setSelectedElement])
 
+  const reset = useCallback(() => {
+    setElements(initialElements)
+  }, [initialElements, setElements])
+
   const value = useMemo(() => ({
     elements,
     selectedElement,
@@ -241,8 +246,9 @@ export function OgEditor({ initialElements, width, height }: OgProviderProps) {
     addElement,
     removeElement,
     undoRedo,
+    reset,
     rootRef,
-  }), [elements, selectedElement, setSelectedElement, setElements, updateElement, addElement, removeElement, undoRedo])
+  }), [elements, selectedElement, setSelectedElement, setElements, updateElement, addElement, removeElement, undoRedo, reset])
 
   return (
     <OgContext.Provider value={value}>

--- a/apps/dashboard/src/lib/export.ts
+++ b/apps/dashboard/src/lib/export.ts
@@ -7,37 +7,34 @@ export function domToReactLike(element: Element, dynamicTextReplace: string): Re
   const props: Record<string, unknown> = {}
   const children = []
 
-  for (const attribute of element.attributes) {
-    if (attribute.name === 'style') {
-      const style: Record<string, string> = {}
-      const declarations = attribute.value.split(/;( |$)/)
+  if (element instanceof HTMLElement) {
+    const style: Record<string, string> = {}
+    const declarations = element.style.cssText.split(/;( |$)/)
 
-      for (const declaration of declarations) {
-        const [property, value] = declaration.split(/:(.*)/)
+    for (const declaration of declarations) {
+      const [property, value] = declaration.split(/:(.*)/)
 
-        if (property && value) {
-          let finalValue = value.trim()
+      if (property && value) {
+        let finalValue = value.trim()
 
-          if (property === 'box-shadow' && finalValue.startsWith('rgb(')) {
-            let rgbValue: string | undefined
+        if (property === 'box-shadow' && finalValue.startsWith('rgb(')) {
+          let rgbValue: string | undefined
 
-            finalValue = finalValue.replace(/rgb\((.*)\)/, (_, rgb) => {
-              rgbValue = rgb as string
-              return ''
-            })
+          finalValue = finalValue.replace(/rgb\((.*)\)/, (_, rgb) => {
+            rgbValue = rgb as string
+            return ''
+          })
 
-            if (rgbValue) {
-              finalValue += ` rgb(${rgbValue})`
-            }
+          if (rgbValue) {
+            finalValue += ` rgb(${rgbValue})`
           }
-
-          style[property] = finalValue
         }
-      }
 
-      props.style = style
-      continue
+        style[property] = finalValue
+      }
     }
+
+    props.style = style
   }
 
   for (const child of element.children) {


### PR DESCRIPTION
Add a new reset button to reset the editor to the initial elements. Will be useful when introducing templates, to reset the editor to the original template:

<img width="229" alt="Screenshot 2023-12-27 at 16 35 45" src="https://github.com/QuiiBz/ogstudio/assets/43268759/0ca1c0e7-ee85-461e-a007-cee15ea03c0e">