### PR TITLE
feat: add "all templates" and "my images" pages

### DIFF
--- a/apps/dashboard/src/app/my-images/page.tsx
+++ b/apps/dashboard/src/app/my-images/page.tsx
@@ -1,5 +1,12 @@
-export default function Templates() {
+import { Suspense } from "react";
+import { OgSplash } from "../../components/OgSplash";
+
+export default function MyImages() {
   return (
-    <p>Todo</p>
+    // OgSplash uses `useSearchParams()` so we need to wrap it in a Suspense
+    // to allow to statically render the page: https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-functions
+    <Suspense>
+      <OgSplash route="my-images" />
+    </Suspense>
   )
 }

--- a/apps/dashboard/src/app/page.tsx
+++ b/apps/dashboard/src/app/page.tsx
@@ -6,7 +6,7 @@ export default function Home() {
     // OgSplash uses `useSearchParams()` so we need to wrap it in a Suspense
     // to allow to statically render the page: https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-functions
     <Suspense>
-      <OgSplash />
+      <OgSplash route="splash" />
     </Suspense>
   )
 }

--- a/apps/dashboard/src/app/templates/page.tsx
+++ b/apps/dashboard/src/app/templates/page.tsx
@@ -1,5 +1,12 @@
+import { Suspense } from "react";
+import { OgSplash } from "../../components/OgSplash";
+
 export default function Templates() {
   return (
-    <p>Todo</p>
+    // OgSplash uses `useSearchParams()` so we need to wrap it in a Suspense
+    // to allow to statically render the page: https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-functions
+    <Suspense>
+      <OgSplash route="templates" />
+    </Suspense>
   )
 }

--- a/apps/dashboard/src/components/OgSplash.tsx
+++ b/apps/dashboard/src/components/OgSplash.tsx
@@ -5,12 +5,14 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { INITIAL_ELEMENTS, createElementId } from "../lib/elements";
 import type { OGElement } from "../lib/types";
+import { TEMPLATES } from "../lib/templates";
 import { OgEditor } from "./OgEditor";
 import { DeleteIcon } from "./icons/DeleteIcon";
 import { AddIcon } from "./icons/AddIcon";
 import { OgImage } from "./OgImage";
 import { ArrowRightIcon } from "./icons/ArrowRightIcon";
 import { CustomLink } from "./CustomLink";
+import { ArrowLeftIcon } from "./icons/ArrowLeftIcon";
 
 interface OgImageWrapperProps {
   href: string
@@ -42,7 +44,11 @@ interface OGImage {
   content: OGElement[]
 }
 
-export function OgSplash() {
+interface OgSplashProps {
+  route: 'splash' | 'templates' | 'my-images'
+}
+
+export function OgSplash({ route }: OgSplashProps) {
   const searchParams = useSearchParams();
   const image = searchParams.get('i')
   const [ogImages, setOgImages] = useState<OGImage[]>([])
@@ -77,39 +83,72 @@ export function OgSplash() {
       <OgEditor height={630} initialElements={INITIAL_ELEMENTS} localStorageKey={image ?? 'splash'} width={1200} />
       {image ? null : (
         <div className="w-screen h-screen bg-black/20 flex justify-center items-center absolute top-0 left-0 z-10 backdrop-blur-[1px]">
-          <div className="p-8 rounded-md bg-white shadow-lg shadow-gray-300 max-w-4xl">
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-row justify-between items-center">
-                <h2 className="text-gray-800 text-xl">Templates</h2>
-                <CustomLink href="/templates" icon={<ArrowRightIcon />} iconPosition="right">
-                  See all
-                </CustomLink>
+          <div className="p-8 rounded-md bg-white shadow-lg shadow-gray-300 w-[calc((300px*3)+(2rem*2)+(0.5rem*2))]">
+            {route === 'splash' ? (
+              <>
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-row justify-between items-center">
+                    <h2 className="text-gray-800 text-xl">Templates</h2>
+                    <CustomLink href="/templates" icon={<ArrowRightIcon />} iconPosition="right">
+                      See all
+                    </CustomLink>
+                  </div>
+                  <div className="flex gap-2">
+                    {TEMPLATES.slice(0, 2).map((template) => (
+                      <OgImageWrapper elements={template.elements} href="/" key={template.name} />
+                    ))}
+                  </div>
+                </div>
+                <div className="h-[1px] w-full bg-gray-100 my-8" />
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-row justify-between items-center">
+                    <h2 className="text-gray-800 text-xl">My OG images</h2>
+                    <CustomLink href="/my-images" icon={<ArrowRightIcon />} iconPosition="right">
+                      See all
+                    </CustomLink>
+                  </div>
+                  <div className="flex gap-2">
+                    <OgImageWrapper href={`/?i=${createElementId()}`}>
+                      <AddIcon height="1.4em" width="1.4em" /> Start from scratch
+                    </OgImageWrapper>
+                    {ogImages.slice(0, 2).map(ogImage => (
+                      <OgImageWrapper deletable={deleteOgImage(ogImage.id)} elements={ogImage.content} href={`/?i=${ogImage.id.replace('og-', '')}`} key={ogImage.id} />
+                    ))}
+                  </div>
+                </div>
+              </>
+            ) : route === 'templates' ? (
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-row justify-between items-center">
+                  <h2 className="text-gray-800 text-xl">All templates</h2>
+                  <CustomLink href="/" icon={<ArrowLeftIcon />}>
+                    Back
+                  </CustomLink>
+                </div>
+                <div className="grid grid-cols-3 gap-2 max-h-[50vh] overflow-y-scroll no-scrollbar">
+                  {TEMPLATES.map((template) => (
+                    <OgImageWrapper elements={template.elements} href="/" key={template.name} />
+                  ))}
+                </div>
               </div>
-              <div className="flex gap-2 overflow-x-scroll no-scrollbar">
-                <OgImageWrapper href="/" />
-                <OgImageWrapper href="/" />
-                <OgImageWrapper href="/" />
-              </div>
-            </div>
-            <div className="h-[1px] w-full bg-gray-100 my-8" />
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-row justify-between items-center">
-                <h2 className="text-gray-800 text-xl">My OG images</h2>
-                <CustomLink href="/my-images" icon={<ArrowRightIcon />} iconPosition="right">
-                  See all
-                </CustomLink>
-              </div>
-              <div className="flex gap-2 overflow-x-scroll no-scrollbar">
-                <OgImageWrapper href={`/?i=${createElementId()}`}>
-                  <AddIcon height="1.4em" width="1.4em" /> Start from scratch
-                </OgImageWrapper>
-                {ogImages.map(ogImage => {
-                  return (
+            ) : (
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-row justify-between items-center">
+                  <h2 className="text-gray-800 text-xl">My OG images</h2>
+                  <CustomLink href="/" icon={<ArrowLeftIcon />}>
+                    Back
+                  </CustomLink>
+                </div>
+                <div className="grid grid-cols-3 gap-2 max-h-[50vh] overflow-y-scroll no-scrollbar">
+                  <OgImageWrapper href={`/?i=${createElementId()}`}>
+                    <AddIcon height="1.4em" width="1.4em" /> Start from scratch
+                  </OgImageWrapper>
+                  {ogImages.map(ogImage => (
                     <OgImageWrapper deletable={deleteOgImage(ogImage.id)} elements={ogImage.content} href={`/?i=${ogImage.id.replace('og-', '')}`} key={ogImage.id} />
-                  )
-                })}
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
           </div>
         </div>
       )}

--- a/apps/dashboard/src/lib/templates.ts
+++ b/apps/dashboard/src/lib/templates.ts
@@ -1,0 +1,30 @@
+import { createElementId } from "./elements";
+import type { OGElement } from "./types";
+
+export interface Template {
+  name: string
+  elements: OGElement[]
+}
+
+/**
+ * The list of all available templates. Each template is composed of an array of
+ * elements and a name.
+ */
+export const TEMPLATES = [
+  {
+    name: 'Default',
+    elements: [{
+      id: createElementId(),
+      tag: 'div',
+      name: 'Box',
+      x: 0,
+      y: 0,
+      width: 1200,
+      height: 630,
+      visible: true,
+      rotate: 0,
+      opacity: 100,
+      backgroundColor: '#ffffff',
+    }]
+  }
+] satisfies Template[]

--- a/apps/dashboard/src/lib/templates.ts
+++ b/apps/dashboard/src/lib/templates.ts
@@ -13,18 +13,92 @@ export interface Template {
 export const TEMPLATES = [
   {
     name: 'Default',
-    elements: [{
-      id: createElementId(),
-      tag: 'div',
-      name: 'Box',
-      x: 0,
-      y: 0,
-      width: 1200,
-      height: 630,
-      visible: true,
-      rotate: 0,
-      opacity: 100,
-      backgroundColor: '#ffffff',
-    }]
+    elements: [
+      {
+        "tag": "div",
+        "id": createElementId(),
+        "name": "Box",
+        "x": 0,
+        "y": 0,
+        "width": 1200,
+        "height": 630,
+        "visible": true,
+        "rotate": 0,
+        "opacity": 100,
+        "backgroundColor": "#ffffff",
+        "gradient": {
+          "start": "#595cff",
+          "end": "#c6f8ff",
+          "angle": 195,
+          "type": "linear"
+        }
+      },
+      {
+        "tag": "p",
+        "id": createElementId(),
+        "name": "Text",
+        "x": 95,
+        "y": 284,
+        "width": 643,
+        "height": 131,
+        "visible": true,
+        "rotate": 0,
+        "opacity": 100,
+        "content": "OG Studio",
+        "color": "#0d0f45",
+        "fontFamily": "Montserrat",
+        "fontWeight": 600,
+        "lineHeight": 1,
+        "fontSize": 120,
+        "align": "left"
+      },
+      {
+        "tag": "p",
+        "id": createElementId(),
+        "name": "Text",
+        "x": 96,
+        "y": 429,
+        "width": 597,
+        "height": 138,
+        "visible": true,
+        "rotate": 0,
+        "opacity": 70,
+        "content": "Image builder",
+        "color": "#0d0f45",
+        "fontFamily": "Montserrat",
+        "fontWeight": 600,
+        "lineHeight": 1,
+        "fontSize": 80,
+        "align": "left"
+      },
+      {
+        "tag": "div",
+        "id": createElementId(),
+        "name": "Rounded box",
+        "x": 956,
+        "y": -78,
+        "width": 307,
+        "height": 307,
+        "visible": true,
+        "rotate": 0,
+        "opacity": 10,
+        "backgroundColor": "#000000",
+        "radius": 999
+      },
+      {
+        "tag": "div",
+        "id": createElementId(),
+        "name": "Rounded box",
+        "x": 1026,
+        "y": -29,
+        "width": 195,
+        "height": 195,
+        "visible": true,
+        "rotate": 0,
+        "opacity": 10,
+        "backgroundColor": "#000000",
+        "radius": 999
+      }
+    ],
   }
 ] satisfies Template[]


### PR DESCRIPTION
Following https://github.com/QuiiBz/ogstudio/pull/15, this PR adds the `/templates` and `/my-images` pages:

![image](https://github.com/QuiiBz/ogstudio/assets/43268759/f3c552c3-f636-461c-82c6-4c2f94c25ea6)

![image](https://github.com/QuiiBz/ogstudio/assets/43268759/60249887-8e74-4a91-acfb-aa95bf499d90)

![image](https://github.com/QuiiBz/ogstudio/assets/43268759/79c3fd19-0fa6-45cb-a529-96ee7e4aaa7b)

