### PR TITLE
refactor: simplify export

### DIFF
--- a/apps/dashboard/src/components/LeftPanel/ExportSection.tsx
+++ b/apps/dashboard/src/components/LeftPanel/ExportSection.tsx
@@ -4,14 +4,16 @@ import { toast } from "sonner";
 import { Button } from "../forms/Button";
 import { PngIcon } from "../icons/PngIcon";
 import { SvgIcon } from "../icons/SvgIcon";
-import { useOg } from "../OgEditor";
-import { domToReactElements, exportToPng, exportToSvg } from "../../lib/export";
+import {
+  elementsToReactElements,
+  exportToPng,
+  exportToSvg,
+} from "../../lib/export";
 import type { FontData } from "../../lib/fonts";
 import { loadFonts } from "../../lib/fonts";
 import { useElementsStore } from "../../stores/elementsStore";
 
 export function ExportSection() {
-  const { rootRef } = useOg();
   const elements = useElementsStore((state) => state.elements);
   const setSelectedElementId = useElementsStore(
     (state) => state.setSelectedElementId,
@@ -31,11 +33,7 @@ export function ExportSection() {
     async function run() {
       setIsLoading(true);
 
-      const reactElements = domToReactElements(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know it's defined
-        rootRef.current!,
-        "This is a dynamic text",
-      );
+      const reactElements = elementsToReactElements(elements);
       const fonts = await loadFonts(elements);
       const svg = await exportToSvg(reactElements, fonts);
 

--- a/apps/dashboard/src/components/OgEditor.tsx
+++ b/apps/dashboard/src/components/OgEditor.tsx
@@ -1,6 +1,5 @@
 "use client";
-import type { RefObject } from "react";
-import { createContext, useContext, useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { OGElement } from "../lib/types";
 import { createElementId } from "../lib/elements";
 import { useZoomStore } from "../stores/zoomStore";
@@ -9,22 +8,6 @@ import { Element } from "./Element";
 import { RightPanel } from "./RightPanel";
 import { LeftPanel } from "./LeftPanel";
 import { EditorToolbar } from "./EditorToolbar";
-
-interface OgContextType {
-  rootRef: RefObject<HTMLDivElement>;
-}
-
-export const OgContext = createContext<OgContextType | null>(null);
-
-export function useOg() {
-  const context = useContext(OgContext);
-
-  if (!context) {
-    throw new Error("useOg must be used within a OgProvider");
-  }
-
-  return context;
-}
 
 interface OgProviderProps {
   imageId: string;
@@ -220,52 +203,43 @@ export function OgEditor({ imageId, width, height }: OgProviderProps) {
     undo,
   ]);
 
-  const value = useMemo(
-    () => ({
-      rootRef,
-    }),
-    [],
-  );
-
   return (
-    <OgContext.Provider value={value}>
-      <div className="w-screen h-screen flex flex-row justify-between items-center bg-gray-50 overflow-hidden">
-        <div className="w-[300px] min-w-[300px] h-screen border-r border-gray-100 shadow-lg shadow-gray-100 bg-white z-10">
-          <LeftPanel />
-        </div>
-        <div className="flex flex-col items-center gap-4 fixed transform left-1/2 -translate-x-1/2">
-          <p className="text-xs text-gray-400 z-10">
-            {width}x{height}
-          </p>
-          <div
-            className="bg-white shadow-lg shadow-gray-100 relative"
-            style={{ width, height, transform: `scale(${zoom / 100})` }}
-          >
-            <div
-              ref={rootRef}
-              style={{ display: "flex", width: "100%", height: "100%" }}
-            >
-              {elements.map((element) => (
-                <Element element={element} key={element.id} />
-              ))}
-            </div>
-          </div>
-          <div
-            className="border border-gray-100 absolute pointer-events-none"
-            style={{
-              width,
-              height,
-              transform: `scale(${zoom / 100}) translateY(${
-                32 / (zoom / 100)
-              }px)`,
-            }}
-          />
-          <EditorToolbar />
-        </div>
-        <div className="w-[300px] min-w-[300px] h-screen flex flex-col border-l border-gray-100 shadow-lg shadow-gray-100 bg-white z-10">
-          <RightPanel />
-        </div>
+    <div className="w-screen h-screen flex flex-row justify-between items-center bg-gray-50 overflow-hidden">
+      <div className="w-[300px] min-w-[300px] h-screen border-r border-gray-100 shadow-lg shadow-gray-100 bg-white z-10">
+        <LeftPanel />
       </div>
-    </OgContext.Provider>
+      <div className="flex flex-col items-center gap-4 fixed transform left-1/2 -translate-x-1/2">
+        <p className="text-xs text-gray-400 z-10">
+          {width}x{height}
+        </p>
+        <div
+          className="bg-white shadow-lg shadow-gray-100 relative"
+          style={{ width, height, transform: `scale(${zoom / 100})` }}
+        >
+          <div
+            ref={rootRef}
+            style={{ display: "flex", width: "100%", height: "100%" }}
+          >
+            {elements.map((element) => (
+              <Element element={element} key={element.id} />
+            ))}
+          </div>
+        </div>
+        <div
+          className="border border-gray-100 absolute pointer-events-none"
+          style={{
+            width,
+            height,
+            transform: `scale(${zoom / 100}) translateY(${
+              32 / (zoom / 100)
+            }px)`,
+          }}
+        />
+        <EditorToolbar />
+      </div>
+      <div className="w-[300px] min-w-[300px] h-screen flex flex-col border-l border-gray-100 shadow-lg shadow-gray-100 bg-white z-10">
+        <RightPanel />
+      </div>
+    </div>
   );
 }

--- a/apps/dashboard/src/lib/__tests__/__snapshots__/export.test.ts.snap
+++ b/apps/dashboard/src/lib/__tests__/__snapshots__/export.test.ts.snap
@@ -1,5 +1,87 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`elementsToReactElements > should not render non-visible elements 1`] = `
+{
+  "props": {
+    "children": [],
+    "style": {
+      "display": "flex",
+      "height": "100%",
+      "width": "100%",
+    },
+  },
+  "type": "div",
+}
+`;
+
+exports[`elementsToReactElements > should render text chidrens 1`] = `
+{
+  "props": {
+    "children": [
+      {
+        "props": {
+          "children": [
+            "Text",
+          ],
+          "style": {
+            "color": "rgba(0, 0, 0, 1)",
+            "fontFamily": "Inter",
+            "fontSize": "50px",
+            "fontWeight": 400,
+            "height": "50px",
+            "left": "0px",
+            "letterSpacing": "0px",
+            "lineHeight": 1,
+            "marginBottom": 0,
+            "marginTop": 0,
+            "position": "absolute",
+            "textAlign": "left",
+            "top": "0px",
+            "width": "100px",
+          },
+        },
+        "type": "p",
+      },
+    ],
+    "style": {
+      "display": "flex",
+      "height": "100%",
+      "width": "100%",
+    },
+  },
+  "type": "div",
+}
+`;
+
+exports[`elementsToReactElements > should render to react elements 1`] = `
+{
+  "props": {
+    "children": [
+      {
+        "props": {
+          "style": {
+            "background": "rgba(255, 255, 255, 1)",
+            "display": "flex",
+            "height": "50px",
+            "left": "0px",
+            "position": "absolute",
+            "top": "0px",
+            "width": "100px",
+          },
+        },
+        "type": "div",
+      },
+    ],
+    "style": {
+      "display": "flex",
+      "height": "100%",
+      "width": "100%",
+    },
+  },
+  "type": "div",
+}
+`;
+
 exports[`exportToPng > should export a basic rectangle to png 1`] = `
 Uint8Array [
   137,
@@ -4418,7 +4500,5 @@ Uint8Array [
   130,
 ]
 `;
-
-exports[`renderToImg > should not render non-visible elements 1`] = `"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIwMCIgaGVpZ2h0PSI2MzAiIHZpZXdCb3g9IjAgMCAxMjAwIDYzMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48bWFzayBpZD0ic2F0b3JpX29tLWlkIj48cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMTIwMCIgaGVpZ2h0PSI2MzAiIGZpbGw9IiNmZmYiLz48L21hc2s+PC9zdmc+"`;
 
 exports[`renderToImg > should render to a base64 data url 1`] = `"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIwMCIgaGVpZ2h0PSI2MzAiIHZpZXdCb3g9IjAgMCAxMjAwIDYzMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48bWFzayBpZD0ic2F0b3JpX29tLWlkIj48cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMTIwMCIgaGVpZ2h0PSI2MzAiIGZpbGw9IiNmZmYiLz48L21hc2s+PG1hc2sgaWQ9InNhdG9yaV9vbS1pZC0wIj48cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMTAwIiBoZWlnaHQ9IjUwIiBmaWxsPSIjZmZmIi8+PC9tYXNrPjxwYXRoIGZpbGw9InJnYmEoMCwgMCwgMCwgMSkiIGQ9Ik0xMy44IDkuM0wyLjQgOS4zTDIuNCA1LjRMMjkuNyA1LjRMMjkuNyA5LjNMMTguMyA5LjNMMTguMyA0MS44TDEzLjggNDEuOEwxMy44IDkuM1pNNDMuNCA0Mi4zTDQzLjQgNDIuM1EzOS41IDQyLjMgMzYuNiA0MC42UTMzLjggMzguOCAzMi4yIDM1LjdRMzAuNyAzMi41IDMwLjcgMjguM1EzMC43IDI0LjEgMzIuMiAyMC45UTMzLjggMTcuNyAzNi41IDE1LjlRMzkuMyAxNC4xIDQzLjAgMTQuMUw0My4wIDE0LjFRNDUuMSAxNC4xIDQ3LjIgMTQuOFE0OS4zIDE1LjYgNTEuMCAxNy4xUTUyLjcgMTguNyA1My43IDIxLjNRNTQuNyAyMy45IDU0LjcgMjcuOEw1NC43IDI3LjhMNTQuNyAyOS41TDM0LjkgMjkuNVEzNS4wIDMyLjMgMzYuMCAzNC4yTDM2LjAgMzQuMlEzNy4wIDM2LjMgMzguOSAzNy41UTQwLjkgMzguNiA0My40IDM4LjZMNDMuNCAzOC42UTQ1LjAgMzguNiA0Ni40IDM4LjFRNDcuNyAzNy42IDQ4LjcgMzYuN1E0OS43IDM1LjcgNTAuMiAzNC4zTDUwLjIgMzQuM0w1NC4zIDM1LjRRNTMuNiAzNy41IDUyLjEgMzkuMFE1MC42IDQwLjYgNDguNCA0MS41UTQ2LjIgNDIuMyA0My40IDQyLjNaTTM0LjkgMjUuOUwzNC45IDI1LjlMNTAuNCAyNS45UTUwLjQgMjMuNiA0OS41IDIxLjhRNDguNiAyMC4wIDQ2LjkgMTguOVE0NS4yIDE3LjkgNDMuMCAxNy45TDQzLjAgMTcuOVE0MC41IDE3LjkgMzguNiAxOS4xUTM2LjggMjAuNCAzNS44IDIyLjNMMzUuOCAyMi4zUTM1LjAgMjQuMCAzNC45IDI1LjlaTTU4LjcgMTQuNUw2My41IDE0LjVMNzAuMCAyNS42TDc2LjYgMTQuNUw4MS40IDE0LjVMNzIuNiAyOC4xTDgxLjQgNDEuOEw3Ni42IDQxLjhMNzAuMCAzMS4yTDYzLjUgNDEuOEw1OC43IDQxLjhMNjcuMyAyOC4xTDU4LjcgMTQuNVpNOTMuNCAxNC41TDk5LjIgMTQuNUw5OS4yIDE4LjBMOTMuNCAxOC4wTDkzLjQgMzMuOVE5My40IDM1LjcgOTMuOSAzNi42UTk0LjQgMzcuNSA5NS4zIDM3LjhROTYuMSAzOC4xIDk3LjAgMzguMUw5Ny4wIDM4LjFROTcuNyAzOC4xIDk4LjIgMzguMFE5OC42IDM3LjkgOTguOSAzNy45TDk4LjkgMzcuOUw5OS43IDQxLjZROTkuMyA0MS44IDk4LjUgNDEuOVE5Ny44IDQyLjEgOTYuNiA0Mi4xTDk2LjYgNDIuMVE5NC44IDQyLjEgOTMuMSA0MS4zUTkxLjQgNDAuNiA5MC4zIDM5LjBRODkuMiAzNy41IDg5LjIgMzUuMUw4OS4yIDM1LjFMODkuMiAxOC4wTDg1LjEgMTguMEw4NS4xIDE0LjVMODkuMiAxNC41TDg5LjIgOC4wTDkzLjQgOC4wTDkzLjQgMTQuNVogIi8+PC9zdmc+"`;

--- a/apps/dashboard/src/lib/__tests__/export.test.ts
+++ b/apps/dashboard/src/lib/__tests__/export.test.ts
@@ -2,71 +2,76 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, it, expect } from "vitest";
 import {
-  domToReactElements,
+  elementsToReactElements,
   exportToPng,
   exportToSvg,
   renderToImg,
 } from "../export";
 import { createElementId } from "../elements";
 
-describe("domToReactElements", () => {
-  it("should transform a dom node to react elements", () => {
-    const element = document.createElement("div");
-    element.innerHTML = "Hello world";
-    element.style.color = "red";
-
-    const output = domToReactElements(element, "");
-    expect(output).toMatchInlineSnapshot(`
+describe("elementsToReactElements", () => {
+  it("should render to react elements", () => {
+    const data = elementsToReactElements([
       {
-        "props": {
-          "children": [
-            "Hello world",
-          ],
-          "style": {
-            "color": "red",
-          },
-        },
-        "type": "div",
-      }
-    `);
+        tag: "div",
+        id: createElementId(),
+        name: "Box",
+        width: 100,
+        height: 50,
+        x: 0,
+        y: 0,
+        visible: true,
+        rotate: 0,
+        opacity: 100,
+        backgroundColor: "#ffffff",
+      },
+    ]);
+    expect(data).toMatchSnapshot();
   });
 
-  it("should transform a dom node to react elements with text children", () => {
-    const element = document.createElement("div");
-    element.innerHTML = "Hello world";
-
-    const output = domToReactElements(element, "");
-    expect(output).toMatchInlineSnapshot(`
+  it("should not render non-visible elements", () => {
+    const data = elementsToReactElements([
       {
-        "props": {
-          "children": [
-            "Hello world",
-          ],
-          "style": {},
-        },
-        "type": "div",
-      }
-    `);
+        tag: "div",
+        id: createElementId(),
+        name: "Box",
+        width: 100,
+        height: 50,
+        x: 0,
+        y: 0,
+        visible: false,
+        rotate: 0,
+        opacity: 100,
+        backgroundColor: "#ffffff",
+      },
+    ]);
+    expect(data).toMatchSnapshot();
   });
 
-  it("should transform a dom node to react elements with styles", () => {
-    const element = document.createElement("div");
-    element.style.color = "red";
-    element.style.backgroundColor = "blue";
-
-    const output = domToReactElements(element, "");
-    expect(output).toMatchInlineSnapshot(`
+  it("should render text chidrens", () => {
+    const data = elementsToReactElements([
       {
-        "props": {
-          "children": [],
-          "style": {
-            "background-color": "blue",
-            "color": "red",
-          },
-        },
-        "type": "div",
-      }
-    `);
+        tag: "p",
+        id: createElementId(),
+        name: "Text",
+        width: 100,
+        height: 50,
+        x: 0,
+        y: 0,
+        visible: true,
+        rotate: 0,
+        opacity: 100,
+        content: "Text",
+        color: "#000000",
+        fontFamily: "Inter",
+        fontWeight: 400,
+        lineHeight: 1,
+        letterSpacing: 0,
+        fontSize: 50,
+        align: "left",
+      },
+    ]);
+    expect(data).toMatchSnapshot();
   });
 });
 
@@ -135,32 +140,6 @@ describe("renderToImg", () => {
         x: 0,
         y: 0,
         visible: true,
-        rotate: 0,
-        opacity: 100,
-        content: "Text",
-        color: "#000000",
-        fontFamily: "Inter",
-        fontWeight: 400,
-        lineHeight: 1,
-        letterSpacing: 0,
-        fontSize: 50,
-        align: "left",
-      },
-    ]);
-    expect(data).toMatchSnapshot();
-  });
-
-  it("should not render non-visible elements", async () => {
-    const data = await renderToImg([
-      {
-        tag: "p",
-        id: createElementId(),
-        name: "Text",
-        width: 100,
-        height: 50,
-        x: 0,
-        y: 0,
-        visible: false,
         rotate: 0,
         opacity: 100,
         content: "Text",


### PR DESCRIPTION
Great simplifications of the export logic:

Instead of having two ways to render an image:
A) Grab the DOM and manually extract the style
B) Grab the elements and use the same `createElementStyle` API as when rendering to the editor
This PR nukes A) and only keeps B), which allows us to remove completely the `OgContext`, `OgProvider` and `useOg`.