### PR TITLE
feat: templates details page

### DIFF
--- a/apps/dashboard/src/app/sitemap.ts
+++ b/apps/dashboard/src/app/sitemap.ts
@@ -1,0 +1,45 @@
+import type { MetadataRoute } from "next";
+import { TEMPLATES } from "../lib/templates";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://ogstudio.app",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+    {
+      url: "https://ogstudio.app/templates",
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    ...TEMPLATES.map<MetadataRoute.Sitemap[number]>((template) => ({
+      url: `https://ogstudio.app/templates/${encodeURIComponent(
+        template.name.toLowerCase(),
+      )}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    })),
+    {
+      url: "https://ogstudio.app/my-images",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: "https://ogstudio.app/profile",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: "https://ogstudio.app/login",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+  ];
+}

--- a/apps/dashboard/src/app/templates/[name]/page.tsx
+++ b/apps/dashboard/src/app/templates/[name]/page.tsx
@@ -1,0 +1,34 @@
+import { TemplateSplash } from "../../../components/Splash/TemplateSplash";
+import { TEMPLATES } from "../../../lib/templates";
+
+interface TemplateProps {
+  params: {
+    name: string;
+  };
+}
+
+export function generateStaticParams() {
+  return TEMPLATES.map((template) => template.name.toLowerCase());
+}
+
+export function generateMetadata({ params: { name } }: TemplateProps) {
+  return {
+    title: `${name} template - OG Studio`,
+    description: "Pre-made Open Graph image templates.",
+  };
+}
+
+export const dynamic = "force-static";
+
+export default function Template({ params: { name } }: TemplateProps) {
+  const decodedName = decodeURIComponent(name);
+  const template = TEMPLATES.find(
+    (current) => current.name.toLowerCase() === decodedName,
+  );
+
+  if (!template) {
+    return null;
+  }
+
+  return <TemplateSplash template={template} />;
+}

--- a/apps/dashboard/src/app/templates/[name]/page.tsx
+++ b/apps/dashboard/src/app/templates/[name]/page.tsx
@@ -12,8 +12,13 @@ export function generateStaticParams() {
 }
 
 export function generateMetadata({ params: { name } }: TemplateProps) {
+  const decodedName = decodeURIComponent(name);
+  const template = TEMPLATES.find(
+    (current) => current.name.toLowerCase() === decodedName,
+  );
+
   return {
-    title: `${name} template - OG Studio`,
+    title: `${template?.name} template - OG Studio`,
     description: "Pre-made Open Graph image templates.",
   };
 }

--- a/apps/dashboard/src/components/OgImage.tsx
+++ b/apps/dashboard/src/components/OgImage.tsx
@@ -2,6 +2,7 @@ import type { MouseEvent, ReactNode } from "react";
 import { Suspense } from "react";
 import Link from "next/link";
 import usePromise from "react-promise-suspense";
+import { clsx } from "clsx";
 import type { OGElement } from "../lib/types";
 import { renderToImg } from "../lib/export";
 import { CopyIcon } from "./icons/CopyIcon";
@@ -25,6 +26,7 @@ interface OgImageProps {
   name?: string;
   copiable?: (event: MouseEvent<HTMLSpanElement>) => void;
   deletable?: (event: MouseEvent<HTMLSpanElement>) => void;
+  size?: "small" | "medium";
 }
 
 export function OgImage({
@@ -35,12 +37,19 @@ export function OgImage({
   name,
   copiable,
   deletable,
+  size,
 }: OgImageProps) {
-  const Tag = href ? Link : "button";
+  const Tag = href ? Link : onClick ? "button" : "div";
 
   return (
     <Tag
-      className="h-[157px] w-[300px] min-w-[300px] flex items-center justify-center text-gray-600 border rounded border-gray-200 hover:border-gray-400 relative group overflow-hidden"
+      className={clsx(
+        "h-[157px] w-[300px] min-w-[300px] flex items-center justify-center text-gray-600 border rounded border-gray-200 hover:border-gray-400 relative group overflow-hidden",
+        {
+          "h-[157px] w-[300px] min-w-[300px]": size === "small",
+          "h-[252px] w-[480px] min-w-[480px]": size === "medium",
+        },
+      )}
       href={href ?? ""}
       onClick={onClick}
     >

--- a/apps/dashboard/src/components/Splash/HomeSplash.tsx
+++ b/apps/dashboard/src/components/Splash/HomeSplash.tsx
@@ -9,8 +9,7 @@ import { useImagesStore } from "../../stores/imagesStore";
 import { OgImage } from "../OgImage";
 
 export function HomeSplash() {
-  const { images, copyTemplate, createEmptyImage, copyImage, deleteImage } =
-    useImagesStore();
+  const { images, createEmptyImage, copyImage, deleteImage } = useImagesStore();
   const router = useRouter();
 
   return (
@@ -30,12 +29,9 @@ export function HomeSplash() {
           {TEMPLATES.slice(0, 3).map((template) => (
             <OgImage
               elements={template.elements}
+              href={`/templates/${template.name.toLowerCase()}`}
               key={template.name}
               name={template.name}
-              onClick={() => {
-                const { id } = copyTemplate(template);
-                router.push(`/?i=${id}`);
-              }}
             />
           ))}
         </div>

--- a/apps/dashboard/src/components/Splash/TemplateSplash.tsx
+++ b/apps/dashboard/src/components/Splash/TemplateSplash.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { CustomLink } from "../CustomLink";
+import { ArrowLeftIcon } from "../icons/ArrowLeftIcon";
+import type { Template } from "../../lib/templates";
+import { Button } from "../forms/Button";
+import { useImagesStore } from "../../stores/imagesStore";
+import { OgImage } from "../OgImage";
+
+interface TemplateSplashProps {
+  template: Template;
+}
+
+export function TemplateSplash({ template }: TemplateSplashProps) {
+  const copyTemplate = useImagesStore((state) => state.copyTemplate);
+  const router = useRouter();
+
+  function useTemplate() {
+    const { id } = copyTemplate(template);
+    router.push(`/?i=${id}`);
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-gray-800 text-xl">{template.name} template</h2>
+        <CustomLink href="/templates" icon={<ArrowLeftIcon />}>
+          Back
+        </CustomLink>
+      </div>
+      <div className="flex gap-4 justify-between">
+        <OgImage elements={template.elements} size="medium" />
+        <div className="flex flex-col gap-8">
+          <p className="text-sm text-gray-600">{template.description}</p>
+          <Button className="w-fit" onClick={useTemplate} variant="success">
+            Start with this template
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Splash/TemplatesSplash.tsx
+++ b/apps/dashboard/src/components/Splash/TemplatesSplash.tsx
@@ -17,7 +17,7 @@ export function TemplatesSplash() {
         {TEMPLATES.map((template) => (
           <OgImage
             elements={template.elements}
-            href="/"
+            href={`/templates/${template.name.toLowerCase()}`}
             key={template.name}
             name={template.name}
           />

--- a/apps/dashboard/src/components/Splash/index.tsx
+++ b/apps/dashboard/src/components/Splash/index.tsx
@@ -31,9 +31,9 @@ function SplashInner({ children }: OgSplashProps) {
       <OgEditor height={630} imageId={image ?? "splash"} width={1200} />
       {image ? null : (
         <div className="w-screen h-screen bg-black/10 flex justify-center items-center absolute top-0 left-0 z-10">
-          <div className="p-8 rounded-md bg-white shadow-lg shadow-gray-200 w-[980px] h-[702px]">
+          <div className="p-8 rounded-md bg-white shadow-lg shadow-gray-200 w-[980px] h-[686px]">
             <div className="flex items-center justify-between">
-              <div className="flex items-center gap-6">
+              <div className="flex items-center gap-6 -mt-2">
                 <Link
                   className="text-gray-900 text-2xl flex gap-2 items-center"
                   href="/"
@@ -85,7 +85,7 @@ function SplashInner({ children }: OgSplashProps) {
                 </CustomLink>
               )}
             </div>
-            <p className="text-sm text-gray-600 mt-2 w-2/3">
+            <p className="text-sm text-gray-600 w-2/3">
               Create static or dynamic Open Graph images with an intuitive,
               Figma-like visual editor. Browse ready-to-use templates, and
               export your images to SVG/PNG or to a dynamic URL.

--- a/apps/dashboard/src/lib/templates.ts
+++ b/apps/dashboard/src/lib/templates.ts
@@ -3,16 +3,19 @@ import type { OGElement } from "./types";
 
 export interface Template {
   name: string;
+  description: string;
   elements: OGElement[];
 }
 
 /**
  * The list of all available templates. Each template is composed of an array of
- * elements and a name.
+ * elements, a name and a description.
  */
 export const TEMPLATES = [
   {
     name: "Default",
+    description:
+      "A simple Open Graph image composed of a title and a subtitle, with a subtle blue gradient.",
     elements: [
       {
         tag: "div",
@@ -105,6 +108,8 @@ export const TEMPLATES = [
   },
   {
     name: "Space",
+    description:
+      'A deep-purple Open Graph image with a "space" vibe, composed of a title and a subtitle.',
     elements: [
       {
         tag: "div",
@@ -337,6 +342,8 @@ export const TEMPLATES = [
   },
   {
     name: "Blog post",
+    description:
+      "Perfect for blog posts, this Open Graph image has an illustration and displays the title and author name.",
     elements: [
       {
         tag: "div",


### PR DESCRIPTION
Add a super basic template details page, as an intermediate step to view a description, a confirmation button (and later, tags and more)

<img width="854" alt="Screenshot 2024-01-21 at 11 03 59" src="https://github.com/QuiiBz/ogstudio/assets/43268759/6c798efe-3c47-4fee-9cf6-b4f9cd294055">

Also add a sitemap.