### PR TITLE
feat: use lambda for og export api

### DIFF
--- a/apps/dashboard/next.config.js
+++ b/apps/dashboard/next.config.js
@@ -30,7 +30,7 @@ const nextConfig = {
         pathname: '/a/*',
       },
     ]
-  },
+  }
 }
 
 module.exports = nextConfig

--- a/apps/dashboard/next.config.js
+++ b/apps/dashboard/next.config.js
@@ -31,12 +31,6 @@ const nextConfig = {
       },
     ]
   },
-  experimental: {
-    outputFileTracingIncludes: {
-      '/api/og/*': ['./src/app/api/og/resvg.wasm'],
-      '/api/og/template/*': ['./src/app/api/og/resvg.wasm'],
-    }
-  }
 }
 
 module.exports = nextConfig

--- a/apps/dashboard/next.config.js
+++ b/apps/dashboard/next.config.js
@@ -30,6 +30,12 @@ const nextConfig = {
         pathname: '/a/*',
       },
     ]
+  },
+  experimental: {
+    outputFileTracingIncludes: {
+      '/api/og/*': ['./src/app/api/og/resvg.wasm'],
+      '/api/og/template/*': ['./src/app/api/og/resvg.wasm'],
+    }
   }
 }
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -19,7 +19,7 @@
     "@ogstudio/auth": "workspace:*",
     "@ogstudio/db": "workspace:*",
     "@radix-ui/themes": "^3.0.3",
-    "@resvg/resvg-wasm": "2.4.0",
+    "@resvg/resvg-wasm": "2.6.2",
     "@tanstack/react-query": "^5.35.1",
     "@vercel/analytics": "^1.2.2",
     "@vercel/kv": "^1.0.1",

--- a/apps/dashboard/src/app/api/og/[key]/route.ts
+++ b/apps/dashboard/src/app/api/og/[key]/route.ts
@@ -8,13 +8,14 @@ import {
   exportToSvg,
 } from "../../../../lib/export";
 import { loadFonts } from "../../../../lib/fonts";
-// @ts-expect-error -- this file does exist
-import resvgWasm from "../resvg.wasm?module";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- wrong type
-const initWasmPromise = initWasm(resvgWasm);
-
-export const runtime = "edge";
+const resvg = fs.readFileSync(
+  url.fileURLToPath(path.join(import.meta.url, '../resvg.wasm'))
+)
+const initWasmPromise = initWasm(resvg);
 
 export async function GET(
   request: NextRequest,

--- a/apps/dashboard/src/app/api/og/[key]/route.ts
+++ b/apps/dashboard/src/app/api/og/[key]/route.ts
@@ -1,5 +1,4 @@
 import { kv } from "@vercel/kv";
-import { initWasm } from "@resvg/resvg-wasm";
 import type { NextRequest } from "next/server";
 import type { OGElement } from "../../../../lib/types";
 import {
@@ -8,14 +7,6 @@ import {
   exportToSvg,
 } from "../../../../lib/export";
 import { loadFonts } from "../../../../lib/fonts";
-import fs from "node:fs";
-import path from "node:path";
-import url from "node:url";
-
-const resvg = fs.readFileSync(
-  url.fileURLToPath(path.join(import.meta.url, '../../resvg.wasm'))
-)
-const initWasmPromise = initWasm(resvg);
 
 export async function GET(
   request: NextRequest,
@@ -33,7 +24,6 @@ export async function GET(
   );
 
   const reactElements = elementsToReactElements(ogElements, dynamicTexts);
-  await initWasmPromise;
   const fonts = await loadFonts(ogElements);
   const svg = await exportToSvg(reactElements, fonts);
   const png = await exportToPng(svg);

--- a/apps/dashboard/src/app/api/og/[key]/route.ts
+++ b/apps/dashboard/src/app/api/og/[key]/route.ts
@@ -13,7 +13,7 @@ import path from "node:path";
 import url from "node:url";
 
 const resvg = fs.readFileSync(
-  url.fileURLToPath(path.join(import.meta.url, '../resvg.wasm'))
+  url.fileURLToPath(path.join(import.meta.url, '../../resvg.wasm'))
 )
 const initWasmPromise = initWasm(resvg);
 

--- a/apps/dashboard/src/app/api/og/template/[name]/route.ts
+++ b/apps/dashboard/src/app/api/og/template/[name]/route.ts
@@ -1,4 +1,3 @@
-import { initWasm } from "@resvg/resvg-wasm";
 import {
   elementsToReactElements,
   exportToPng,
@@ -6,14 +5,6 @@ import {
 } from "../../../../../lib/export";
 import { TEMPLATES } from "../../../../../lib/templates";
 import { loadFonts } from "../../../../../lib/fonts";
-import fs from "node:fs";
-import path from "node:path";
-import url from "node:url";
-
-const resvg = fs.readFileSync(
-  url.fileURLToPath(path.join(import.meta.url, '../../../resvg.wasm'))
-)
-const initWasmPromise = initWasm(resvg);
 
 export async function GET(
   _: Request,
@@ -30,7 +21,6 @@ export async function GET(
 
   const ogElements = template.elements;
   const reactElements = elementsToReactElements(ogElements);
-  await initWasmPromise;
   const fonts = await loadFonts(ogElements);
   const svg = await exportToSvg(reactElements, fonts);
   const png = await exportToPng(svg);

--- a/apps/dashboard/src/app/api/og/template/[name]/route.ts
+++ b/apps/dashboard/src/app/api/og/template/[name]/route.ts
@@ -5,14 +5,15 @@ import {
   exportToSvg,
 } from "../../../../../lib/export";
 import { TEMPLATES } from "../../../../../lib/templates";
-// @ts-expect-error -- this file does exist
-import resvgWasm from "../../resvg.wasm?module";
 import { loadFonts } from "../../../../../lib/fonts";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- wrong type
-const initWasmPromise = initWasm(resvgWasm);
-
-export const runtime = "edge";
+const resvg = fs.readFileSync(
+  url.fileURLToPath(path.join(import.meta.url, '../../resvg.wasm'))
+)
+const initWasmPromise = initWasm(resvg);
 
 export async function GET(
   _: Request,

--- a/apps/dashboard/src/app/api/og/template/[name]/route.ts
+++ b/apps/dashboard/src/app/api/og/template/[name]/route.ts
@@ -11,7 +11,7 @@ import path from "node:path";
 import url from "node:url";
 
 const resvg = fs.readFileSync(
-  url.fileURLToPath(path.join(import.meta.url, '../../resvg.wasm'))
+  url.fileURLToPath(path.join(import.meta.url, '../../../resvg.wasm'))
 )
 const initWasmPromise = initWasm(resvg);
 

--- a/apps/dashboard/src/lib/export.ts
+++ b/apps/dashboard/src/lib/export.ts
@@ -16,11 +16,11 @@ if (process.env.VITEST_POOL_ID) {
       "node_modules/@resvg/resvg-wasm/index_bg.wasm",
     ),
   );
-} {
+} else {
   initWasmPromise = initWasm(
     fetch("https://unpkg.com/@resvg/resvg-wasm@2.4.0/index_bg.wasm", {
       cache: "no-store",
-    })
+    }),
   );
 }
 
@@ -77,9 +77,9 @@ export function elementsToReactElements(
             props: {
               style: isImage
                 ? {
-                  ...createElementStyle(element),
-                  ...createImgElementStyle(element),
-                }
+                    ...createElementStyle(element),
+                    ...createImgElementStyle(element),
+                  }
                 : createElementStyle(element),
               ...(isImage
                 ? { src: dynamicText ? dynamicText : element.backgroundImage }

--- a/apps/dashboard/src/lib/export.ts
+++ b/apps/dashboard/src/lib/export.ts
@@ -18,7 +18,7 @@ if (process.env.VITEST_POOL_ID) {
   );
 } else {
   initWasmPromise = initWasm(
-    fetch("https://unpkg.com/@resvg/resvg-wasm@2.4.0/index_bg.wasm", {
+    fetch("https://unpkg.com/@resvg/resvg-wasm@2.6.2/index_bg.wasm", {
       cache: "no-store",
     }),
   );

--- a/apps/dashboard/src/lib/fonts.ts
+++ b/apps/dashboard/src/lib/fonts.ts
@@ -81,7 +81,7 @@ export async function loadFonts(elements: OGElement[]): Promise<FontData[]> {
         const fontName = element.fontFamily.toLowerCase().replace(" ", "-");
         const data = await fetch(
           // @ts-expect-error -- wrong inference
-          `https://fonts.bunny.net/${fontName}/files/${fontName}-latin-${element.fontWeight}-normal.woff`,
+          `https://fonts.bunny.net/${fontName}/files/${fontName}-latin-${element.fontWeight}-normal.woff`, { cache: 'no-store' }
         ).then((response) => response.arrayBuffer());
 
         const fontData: FontData = {

--- a/apps/dashboard/src/lib/fonts.ts
+++ b/apps/dashboard/src/lib/fonts.ts
@@ -81,7 +81,8 @@ export async function loadFonts(elements: OGElement[]): Promise<FontData[]> {
         const fontName = element.fontFamily.toLowerCase().replace(" ", "-");
         const data = await fetch(
           // @ts-expect-error -- wrong inference
-          `https://fonts.bunny.net/${fontName}/files/${fontName}-latin-${element.fontWeight}-normal.woff`, { cache: 'no-store' }
+          `https://fonts.bunny.net/${fontName}/files/${fontName}-latin-${element.fontWeight}-normal.woff`,
+          { cache: "no-store" },
         ).then((response) => response.arrayBuffer());
 
         const fontData: FontData = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -821,6 +821,7 @@ packages:
   '@humanwhocodes/config-array@0.11.13':
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -828,6 +829,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.1':
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
+    deprecated: Use @eslint/object-schema instead
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3100,6 +3102,7 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -4061,6 +4064,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup@4.9.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3(@types/react-dom@18.2.18)(@types/react@18.2.45)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@resvg/resvg-wasm':
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: 2.6.2
+        version: 2.6.2
       '@tanstack/react-query':
         specifier: ^5.35.1
         version: 5.35.1(react@18.2.0)
@@ -1777,8 +1777,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@resvg/resvg-wasm@2.4.0':
-    resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
+  '@resvg/resvg-wasm@2.6.2':
+    resolution: {integrity: sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw==}
     engines: {node: '>= 10'}
 
   '@rollup/rollup-android-arm-eabi@4.9.1':
@@ -6199,7 +6199,7 @@ snapshots:
       '@types/react': 18.2.45
       '@types/react-dom': 18.2.18
 
-  '@resvg/resvg-wasm@2.4.0': {}
+  '@resvg/resvg-wasm@2.6.2': {}
 
   '@rollup/rollup-android-arm-eabi@4.9.1':
     optional: true


### PR DESCRIPTION
Simplify the codebase by always using the same path to load resvg-wasm, and likely better performance since it's a CPU-bound process.