### PR TITLE
feat: improve toolbar, add shortcuts

### DIFF
--- a/apps/dashboard/src/components/EditorToolbar.tsx
+++ b/apps/dashboard/src/components/EditorToolbar.tsx
@@ -1,5 +1,13 @@
-import { Card, Flex, IconButton, Separator, Text } from "@radix-ui/themes";
-import { createElement } from "../lib/elements";
+import {
+  Card,
+  Flex,
+  IconButton,
+  Separator,
+  Text,
+  Tooltip,
+} from "@radix-ui/themes";
+import { type MouseEvent } from "react";
+import { createDefaultElement, type ElementType } from "../lib/elements";
 import { useZoomStore } from "../stores/zoomStore";
 import { useElementsStore } from "../stores/elementsStore";
 import { TextIcon } from "./icons/TextIcon";
@@ -14,161 +22,111 @@ export function EditorToolbar() {
   const addElement = useElementsStore((state) => state.addElement);
   const { zoom, zoomIn, zoomOut } = useZoomStore();
 
+  function addNewElement(
+    event: MouseEvent<HTMLButtonElement>,
+    type: ElementType,
+  ) {
+    // Un-focus the clicked button since we'll be focusing the new element
+    event.currentTarget.blur();
+
+    addElement(createDefaultElement(type));
+  }
+
   return (
     <Flex gap="4">
       <Card variant="classic">
         <Flex align="center" gap="4">
-          <IconButton
-            color="gray"
-            onClick={() => {
-              addElement(
-                createElement({
-                  tag: "p",
-                  name: "Text",
-                  width: 100,
-                  height: 50,
-                  visible: true,
-                  rotate: 0,
-                  blur: 0,
-                  content: "Text",
-                  color: "#000000",
-                  fontFamily: "Inter",
-                  fontWeight: 400,
-                  lineHeight: 1,
-                  letterSpacing: 0,
-                  fontSize: 50,
-                  align: "left",
-                }),
-              );
-            }}
-            variant="ghost"
-          >
-            <TextIcon height="1.4em" width="1.4em" />
-          </IconButton>
+          <Tooltip content="Text • T">
+            <IconButton
+              color="gray"
+              onClick={(event) => {
+                addNewElement(event, "text");
+              }}
+              variant="ghost"
+            >
+              <TextIcon height="1.4em" width="1.4em" />
+            </IconButton>
+          </Tooltip>
           <Separator orientation="vertical" />
-          <IconButton
-            color="gray"
-            onClick={() => {
-              addElement(
-                createElement({
-                  tag: "div",
-                  name: "Box",
-                  width: 200,
-                  height: 200,
-                  visible: true,
-                  rotate: 0,
-                  blur: 0,
-                  radius: 0,
-                  backgroundColor: "#000000",
-                }),
-              );
-            }}
-            variant="ghost"
-          >
-            <BoxIcon height="1.4em" width="1.4em" />
-          </IconButton>
+          <Tooltip content="Box • B">
+            <IconButton
+              color="gray"
+              onClick={(event) => {
+                addNewElement(event, "box");
+              }}
+              variant="ghost"
+            >
+              <BoxIcon height="1.4em" width="1.4em" />
+            </IconButton>
+          </Tooltip>
           <Separator orientation="vertical" />
-          <IconButton
-            color="gray"
-            onClick={() => {
-              addElement(
-                createElement({
-                  tag: "div",
-                  name: "Rounded box",
-                  width: 150,
-                  height: 150,
-                  visible: true,
-                  rotate: 0,
-                  blur: 0,
-                  backgroundColor: "#000000",
-                  radius: 999,
-                }),
-              );
-            }}
-            variant="ghost"
-          >
-            <CircleIcon height="1.4em" width="1.4em" />
-          </IconButton>
+          <Tooltip content="Rounded Box • C">
+            <IconButton
+              color="gray"
+              onClick={(event) => {
+                addNewElement(event, "rounded-box");
+              }}
+              variant="ghost"
+            >
+              <CircleIcon height="1.4em" width="1.4em" />
+            </IconButton>
+          </Tooltip>
           <Separator orientation="vertical" />
-          <IconButton
-            color="gray"
-            onClick={() => {
-              addElement(
-                createElement({
-                  tag: "div",
-                  name: "Image",
-                  width: 200,
-                  height: 150,
-                  visible: true,
-                  rotate: 0,
-                  blur: 0,
-                  radius: 0,
-                  backgroundColor: "#000000",
-                  backgroundImage: "https://source.unsplash.com/random",
-                  backgroundSize: "cover",
-                }),
-              );
-            }}
-            variant="ghost"
-          >
-            <ImageIcon height="1.4em" width="1.4em" />
-          </IconButton>
+          <Tooltip content="Image • I">
+            <IconButton
+              color="gray"
+              onClick={(event) => {
+                addNewElement(event, "image");
+              }}
+              variant="ghost"
+            >
+              <ImageIcon height="1.4em" width="1.4em" />
+            </IconButton>
+          </Tooltip>
           <Separator orientation="vertical" />
-          <IconButton
-            color="gray"
-            onClick={() => {
-              addElement(
-                createElement({
-                  tag: "span",
-                  name: "Dynamic text",
-                  width: 312,
-                  height: 50,
-                  visible: true,
-                  rotate: 0,
-                  blur: 0,
-                  content: "dynamic",
-                  color: "#000000",
-                  fontFamily: "Inter",
-                  fontWeight: 400,
-                  lineHeight: 1,
-                  letterSpacing: 0,
-                  fontSize: 50,
-                  align: "left",
-                }),
-              );
-            }}
-            variant="ghost"
-          >
-            <MagicWandIcon height="1.4em" width="1.4em" />
-          </IconButton>
+          <Tooltip content="Dynamic Text • D">
+            <IconButton
+              color="gray"
+              onClick={(event) => {
+                addNewElement(event, "dynamic-text");
+              }}
+              variant="ghost"
+            >
+              <MagicWandIcon height="1.4em" width="1.4em" />
+            </IconButton>
+          </Tooltip>
         </Flex>
       </Card>
       <Card variant="classic">
         <Flex align="center" gap="4">
-          <IconButton
-            color="gray"
-            onClick={() => {
-              zoomOut();
-            }}
-            variant="ghost"
-          >
-            <ZoomOutIcon height="1.4em" width="1.4em" />
-          </IconButton>
+          <Tooltip content="Zoom Out">
+            <IconButton
+              color="gray"
+              onClick={() => {
+                zoomOut();
+              }}
+              variant="ghost"
+            >
+              <ZoomOutIcon height="1.4em" width="1.4em" />
+            </IconButton>
+          </Tooltip>
           <Separator orientation="vertical" />
           {/* Set absolute width to make sure it doesn't change the layout */}
           <Text align="center" className="select-none min-w-[40px]" size="1">
             {zoom}%
           </Text>
           <Separator orientation="vertical" />
-          <IconButton
-            color="gray"
-            onClick={() => {
-              zoomIn();
-            }}
-            variant="ghost"
-          >
-            <ZoomInIcon height="1.4em" width="1.4em" />
-          </IconButton>
+          <Tooltip content="Zoom In">
+            <IconButton
+              color="gray"
+              onClick={() => {
+                zoomIn();
+              }}
+              variant="ghost"
+            >
+              <ZoomInIcon height="1.4em" width="1.4em" />
+            </IconButton>
+          </Tooltip>
         </Flex>
       </Card>
     </Flex>

--- a/apps/dashboard/src/components/OgEditor.tsx
+++ b/apps/dashboard/src/components/OgEditor.tsx
@@ -2,8 +2,13 @@
 import { useEffect, useRef } from "react";
 import { Box, Flex } from "@radix-ui/themes";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import type { OGElement } from "../lib/types";
-import { createElementId } from "../lib/elements";
+import {
+  createDefaultElement,
+  createElement,
+  createElementId,
+} from "../lib/elements";
 import { useZoomStore } from "../stores/zoomStore";
 import { useElementsStore } from "../stores/elementsStore";
 import { useImagesStore } from "../stores/imagesStore";
@@ -188,6 +193,38 @@ export function OgEditor({ imageId, width, height }: OgProviderProps) {
           addElement(newElement);
           elementIdToCopy = newElement.id;
         }
+      }
+
+      // When trying to save the document, show a toast
+      if (event.key === "s" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        toast("Your work is saved automatically!");
+      }
+
+      // Insert elements with keyboard shortcuts
+      if (event.key === "t") {
+        event.preventDefault();
+        addElement(createDefaultElement("text"));
+      }
+
+      if (event.key === "b") {
+        event.preventDefault();
+        addElement(createDefaultElement("box"));
+      }
+
+      if (event.key === "o") {
+        event.preventDefault();
+        addElement(createDefaultElement("rounded-box"));
+      }
+
+      if (event.key === "i") {
+        event.preventDefault();
+        addElement(createDefaultElement("image"));
+      }
+
+      if (event.key === "d") {
+        event.preventDefault();
+        addElement(createDefaultElement("dynamic-text"));
       }
     }
 

--- a/apps/dashboard/src/components/OgEditor.tsx
+++ b/apps/dashboard/src/components/OgEditor.tsx
@@ -4,11 +4,7 @@ import { Box, Flex } from "@radix-ui/themes";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { OGElement } from "../lib/types";
-import {
-  createDefaultElement,
-  createElement,
-  createElementId,
-} from "../lib/elements";
+import { createDefaultElement, createElementId } from "../lib/elements";
 import { useZoomStore } from "../stores/zoomStore";
 import { useElementsStore } from "../stores/elementsStore";
 import { useImagesStore } from "../stores/imagesStore";

--- a/apps/dashboard/src/lib/elements.ts
+++ b/apps/dashboard/src/lib/elements.ts
@@ -95,7 +95,7 @@ export function createDefaultElement(type: ElementType): OGElement {
         visible: true,
         rotate: 0,
         blur: 0,
-        radius: 10,
+        radius: 999,
         backgroundColor: "#000000",
       });
     }

--- a/apps/dashboard/src/lib/elements.ts
+++ b/apps/dashboard/src/lib/elements.ts
@@ -41,6 +41,93 @@ export function createElement(element: Partial<OGElement>): OGElement {
   };
 }
 
+// All different types of elements that can be added to the canvas.
+export type ElementType =
+  | "text"
+  | "box"
+  | "rounded-box"
+  | "image"
+  | "dynamic-text";
+
+/**
+ * Create a new element with default values based on its type.
+ */
+export function createDefaultElement(type: ElementType): OGElement {
+  switch (type) {
+    case "text": {
+      return createElement({
+        tag: "p",
+        name: "Text",
+        width: 100,
+        height: 50,
+        visible: true,
+        rotate: 0,
+        blur: 0,
+        content: "Text",
+        color: "#000000",
+        fontFamily: "Inter",
+        fontWeight: 400,
+        lineHeight: 1,
+        letterSpacing: 0,
+        fontSize: 50,
+        align: "left",
+      });
+    }
+    case "box": {
+      return createElement({
+        tag: "div",
+        name: "Box",
+        width: 200,
+        height: 200,
+        visible: true,
+        rotate: 0,
+        blur: 0,
+        radius: 0,
+        backgroundColor: "#000000",
+      });
+    }
+    case "rounded-box": {
+      return createElement({
+        tag: "div",
+        name: "Rounded box",
+        width: 150,
+        height: 150,
+        visible: true,
+        rotate: 0,
+        blur: 0,
+        radius: 10,
+        backgroundColor: "#000000",
+      });
+    }
+    case "image": {
+      return createElement({
+        tag: "div",
+        name: "Image",
+        width: 200,
+        height: 200,
+        visible: true,
+        rotate: 0,
+        blur: 0,
+        radius: 0,
+        backgroundImage: "",
+      });
+    }
+    case "dynamic-text": {
+      return createElement({
+        tag: "div",
+        name: "Dynamic text",
+        width: 200,
+        height: 200,
+        visible: true,
+        rotate: 0,
+        blur: 0,
+        radius: 0,
+        backgroundImage: "",
+      });
+    }
+  }
+}
+
 /**
  * Generate the CSS styles for an element. This will also be used by Satori to
  * render the elements to an SVG, so we have to only use CSS properties that


### PR DESCRIPTION
Add shortcuts to add new elements and tooltips to show the keybind:

<img width="532" alt="Screenshot 2024-09-07 at 08 23 59" src="https://github.com/user-attachments/assets/5239be2f-3447-4c65-9cbb-23659fd4609f">

Also unfocus toolbar buttons when clicking on them, since the focus is then on the created element.