### PR TITLE
feat: improve color picker

### DIFF
--- a/apps/dashboard/src/components/ColorPicker.tsx
+++ b/apps/dashboard/src/components/ColorPicker.tsx
@@ -1,6 +1,15 @@
-import { Button, Flex, Popover, TextField } from "@radix-ui/themes";
+import {
+  Button,
+  Flex,
+  Grid,
+  Popover,
+  Separator,
+  Text,
+  TextField,
+} from "@radix-ui/themes";
 import { HexAlphaColorPicker } from "react-colorful";
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
+import { useElementsStore } from "../stores/elementsStore";
 import { ColorIcon } from "./icons/ColorIcon";
 
 interface ColorPickerProps {
@@ -10,6 +19,37 @@ interface ColorPickerProps {
 }
 
 export function ColorPicker({ value, onChange, children }: ColorPickerProps) {
+  const elements = useElementsStore((state) => state.elements);
+  const colors = useMemo(() => {
+    // Loop through all elements and extract all colors in the image
+    const set = new Set<string>();
+
+    for (const element of elements) {
+      if ("color" in element) {
+        set.add(element.color);
+      }
+
+      if ("backgroundColor" in element) {
+        set.add(element.backgroundColor);
+      }
+
+      if (element.border?.color) {
+        set.add(element.border.color);
+      }
+
+      if (element.shadow?.color) {
+        set.add(element.shadow.color);
+      }
+
+      if ("gradient" in element && element.gradient) {
+        set.add(element.gradient.start);
+        set.add(element.gradient.end);
+      }
+    }
+
+    return Array.from(set);
+  }, [elements]);
+
   return (
     <Popover.Root>
       <Popover.Trigger>
@@ -19,22 +59,47 @@ export function ColorPicker({ value, onChange, children }: ColorPickerProps) {
         </Button>
       </Popover.Trigger>
       <Popover.Content minWidth="268px">
-        <Flex direction="column" gap="2">
-          <HexAlphaColorPicker color={value} onChange={onChange} />
-          <TextField.Root
-            color="gray"
-            onChange={(event) => {
-              const newValue = event.target.value;
+        <Flex direction="column" gap="4">
+          <Flex direction="column" gap="2">
+            <Text size="1">Color picker</Text>
+            <HexAlphaColorPicker color={value} onChange={onChange} />
+            <TextField.Root
+              color="gray"
+              onChange={(event) => {
+                const newValue = event.target.value;
 
-              if (!newValue.startsWith("#")) {
-                return;
-              }
-
-              onChange(newValue);
-            }}
-            value={value}
-            variant="soft"
-          />
+                if (newValue.startsWith("#")) {
+                  onChange(newValue);
+                } else {
+                  onChange(`#${newValue}`);
+                }
+              }}
+              value={value}
+              variant="soft"
+              // eslint-disable-next-line -- Usability and accessibility for users is not reduced here
+              autoFocus
+            />
+          </Flex>
+          <Separator className="opacity-50" size="4" />
+          <Flex direction="column" gap="2">
+            <Text size="1">Recently used</Text>
+            <Grid columns="6">
+              {colors.map((color) => (
+                <button
+                  type="button"
+                  key={color}
+                  onClick={() => {
+                    onChange(color);
+                  }}
+                  className="rounded-md w-6 h-6 border"
+                  style={{
+                    backgroundColor: color,
+                    borderColor: "var(--gray-6)",
+                  }}
+                />
+              ))}
+            </Grid>
+          </Flex>
         </Flex>
       </Popover.Content>
     </Popover.Root>

--- a/apps/dashboard/src/components/ColorPicker.tsx
+++ b/apps/dashboard/src/components/ColorPicker.tsx
@@ -83,7 +83,7 @@ export function ColorPicker({ value, onChange, children }: ColorPickerProps) {
           <Separator className="opacity-50" size="4" />
           <Flex direction="column" gap="2">
             <Text size="1">Recently used</Text>
-            <Grid columns="6">
+            <Grid columns="8" gap="2">
               {colors.map((color) => (
                 <button
                   type="button"

--- a/apps/dashboard/src/components/EditorTitle.tsx
+++ b/apps/dashboard/src/components/EditorTitle.tsx
@@ -24,7 +24,7 @@ export function EditorTitle() {
 
   return (
     <Box
-      className="transform -translate-x-1/2"
+      className="transform -translate-x-1/2 z-50"
       left="50%"
       p="6"
       position="absolute"


### PR DESCRIPTION
- Add "Recently used" colors
- Add separator and titles
- Auto-focus the hex color on popup

Before:
![image](https://github.com/user-attachments/assets/dd73223b-c1d0-43f0-aaf6-c79e55bf1e8a)

After:
![image](https://github.com/user-attachments/assets/2f118d6d-3d65-4835-8429-d69807c4660a)
