### PR TITLE
fix: missing meta tags

### DIFF
--- a/apps/dashboard/src/app/(splash)/login/page.tsx
+++ b/apps/dashboard/src/app/(splash)/login/page.tsx
@@ -6,6 +6,10 @@ import { GoogleIcon } from "../../../components/icons/GoogleIcon";
 export const metadata = {
   title: "Sign in - OG Studio",
   openGraph: {
+    siteName: "OG Studio",
+    images:
+      "https://github.com/QuiiBz/ogstudio/blob/main/assets/builder.jpeg?raw=true",
+    type: "website",
     url: "https://ogstudio.app/login",
   },
 };

--- a/apps/dashboard/src/app/(splash)/my-images/page.tsx
+++ b/apps/dashboard/src/app/(splash)/my-images/page.tsx
@@ -3,6 +3,10 @@ import { MyImagesSplash } from "../../../components/Splash/MyImagesSplash";
 export const metadata = {
   title: "My Open Graph images - OG Studio",
   openGraph: {
+    siteName: "OG Studio",
+    images:
+      "https://github.com/QuiiBz/ogstudio/blob/main/assets/builder.jpeg?raw=true",
+    type: "website",
     url: "https://ogstudio.app/my-images",
   },
 };

--- a/apps/dashboard/src/app/(splash)/profile/page.tsx
+++ b/apps/dashboard/src/app/(splash)/profile/page.tsx
@@ -4,6 +4,9 @@ import { Profile } from "../../../components/Profile";
 export const metadata: Metadata = {
   title: "Profile - OG Studio",
   openGraph: {
+    siteName: "OG Studio",
+    images:
+      "https://github.com/QuiiBz/ogstudio/blob/main/assets/builder.jpeg?raw=true",
     type: "profile",
     url: "https://ogstudio.app/profile",
   },

--- a/apps/dashboard/src/app/(splash)/templates/page.tsx
+++ b/apps/dashboard/src/app/(splash)/templates/page.tsx
@@ -5,6 +5,10 @@ export const metadata = {
   description:
     "Free, pre-made Open Graph image templates. Create static or dynamic OG (Open Graph) images with an intuitive, Figma-like visual editor.",
   openGraph: {
+    siteName: "OG Studio",
+    images:
+      "https://github.com/QuiiBz/ogstudio/blob/main/assets/builder.jpeg?raw=true",
+    type: "website",
     url: "https://ogstudio.app/templates",
   },
 };

--- a/apps/dashboard/src/app/(splash)/tools/open-graph-image-checker/page.tsx
+++ b/apps/dashboard/src/app/(splash)/tools/open-graph-image-checker/page.tsx
@@ -8,6 +8,10 @@ export const metadata: Metadata = {
   description:
     "Free tool to check Open Graph meta tags of any website. Create static or dynamic OG (Open Graph) images with an intuitive, Figma-like visual editor.",
   openGraph: {
+    siteName: "OG Studio",
+    images:
+      "https://github.com/QuiiBz/ogstudio/blob/main/assets/builder.jpeg?raw=true",
+    type: "website",
     url: "https://ogstudio.app/tools/open-graph-image-checker",
   },
 };

--- a/apps/dashboard/src/app/editor/page.tsx
+++ b/apps/dashboard/src/app/editor/page.tsx
@@ -3,6 +3,10 @@ import { Editor } from "../../components/Editor";
 export const metadata = {
   title: "Editor - OG Studio",
   openGraph: {
+    siteName: "OG Studio",
+    images:
+      "https://github.com/QuiiBz/ogstudio/blob/main/assets/builder.jpeg?raw=true",
+    type: "website",
     url: "https://ogstudio.app/editor",
   },
 };


### PR DESCRIPTION
Follow-up to https://github.com/QuiiBz/ogstudio/pull/112

Turns out Next.js doesn't deeply clone the `openGraph` property from parent layouts, so we have to redeclare each sub-property again.